### PR TITLE
Fix wrong reported grade

### DIFF
--- a/pkg/exporter/grades.go
+++ b/pkg/exporter/grades.go
@@ -23,25 +23,32 @@ var gradesMapping = map[string]float64{
 }
 
 // convert the returned grade to a number based on https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide
-func endpointsLowestGrade(ep []ssllabs.Endpoint) string {
+func endpointsLowestGrade(ep []ssllabs.Endpoint) (result string) {
 	if len(ep) == 0 {
-		return ""
+		return
 	}
-
-	// initialize the returned grade to the highest possible value
-	grade := "A+"
 
 	// the target host gets the lowest score of its endpoints
 	for _, e := range ep {
+		// skip endpoints without a grade : case of unreachable endpoint(s)
+		if e.Grade == "" {
+			continue
+		}
+
+		// initialize the result with the first defined grade
+		if result == "" {
+			result = e.Grade
+		}
+
 		eGrade, ok := gradesMapping[e.Grade]
 		if ok {
-			if gradesMapping[grade] > eGrade {
-				grade = e.Grade
+			if gradesMapping[result] > eGrade {
+				result = e.Grade
 			}
 		} else {
 			return "undef"
 		}
 	}
 
-	return grade
+	return
 }

--- a/pkg/exporter/grades_test.go
+++ b/pkg/exporter/grades_test.go
@@ -32,6 +32,32 @@ func TestEndpointsLowestGrade(t *testing.T) {
 			expectedResult: "",
 		},
 		{
+			name: "result_with_unreachable_endpoint(s)",
+			data: []ssllabs.Endpoint{
+				{
+					StatusMessage: "Unable to connect to the server",
+					Grade:         "",
+				},
+			},
+			expectedResult: "",
+		},
+		{
+			name: "result_with_single_unreachable_endpoint",
+			data: []ssllabs.Endpoint{
+				{
+					StatusMessage: "Unable to connect to the server",
+					Grade:         "",
+				},
+				{
+					Grade: "A",
+				},
+				{
+					Grade: "B",
+				},
+			},
+			expectedResult: "B",
+		},
+		{
 			name: "single_grade",
 			data: []ssllabs.Endpoint{
 				{

--- a/pkg/ssllabs/info_test.go
+++ b/pkg/ssllabs/info_test.go
@@ -26,7 +26,7 @@ func TestInfo(t *testing.T) {
 	}
 
 	expectedInfo := APIInfo{
-		EngineVersion:      "2.1.0",
+		EngineVersion:      "2.1.3",
 		CriteriaVersion:    "2009q",
 		MaxAssessments:     25,
 		CurrentAssessments: 0,


### PR DESCRIPTION
Follow up for https://github.com/anas-aso/ssllabs_exporter/pull/4

Previously a target host with unreachable endpoints would get `ssllabs_grade{grade="undef"} 1` which is wrong. With this change a the result will be `ssllabs_grade{grade="-"} 0`

PS: "unreachable endpoint" case happens when SSLLabs cannot establish SSL/TLS connection with the endpoint.