### PR TITLE
Fix reporting time

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -42,8 +42,8 @@ func Handle(ctx context.Context, logger log.Logger, target string) prometheus.Ga
 			Name: "ssllabs_grade",
 			Help: "Displays the returned SSLLabs grade of the target host",
 		}, []string{"grade"})
-		probeAgeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "ssllabs_grade_age_seconds",
+		probeTimeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "ssllabs_grade_time_seconds",
 			Help: "Displays the assessment time for the target host",
 		})
 	)
@@ -51,10 +51,10 @@ func Handle(ctx context.Context, logger log.Logger, target string) prometheus.Ga
 	registry.MustRegister(probeDurationGauge)
 	registry.MustRegister(probeSuccessGauge)
 	registry.MustRegister(probeGaugeVec)
-	registry.MustRegister(probeAgeGauge)
+	registry.MustRegister(probeTimeGauge)
 
 	start := time.Now()
-	probeAgeGauge.Set(float64(start.Unix()))
+	probeTimeGauge.Set(float64(start.Unix()))
 
 	result, err := ssllabs.Analyze(ctx, logger, target)
 


### PR DESCRIPTION
Sometimes SSLLabs API reports "older" assessment processing time. I don't think it's a cache, since the reported time is even older than the previous successful assessment.
This behavior breaks any alert based on `ssllabs_grade_age_seconds` to detect stale grade results.

To avoid this issue, this PR uses the time when the assessment started as the new value for that metrics. 

The metric name was also changed from `ssllabs_grade_age_seconds` to `ssllabs_grade_time_seconds` which is more descriptive.