### PR TITLE
Set HTTP timeout for SSLLabs API requests.

### DIFF
--- a/pkg/ssllabs/analyze.go
+++ b/pkg/ssllabs/analyze.go
@@ -150,7 +150,9 @@ func getAnalyze(target string, new bool) (result Result) {
 		request += "&startNew=on"
 	}
 
-	response, err := http.Get(request)
+	// TODO: make http timeout configurable
+	httpClient := http.Client{Timeout: 1 * time.Minute}
+	response, err := httpClient.Get(request)
 	if err != nil {
 		result.Status = StatusHTTPError
 		return


### PR DESCRIPTION
The exporter was leaking goroutines due to the lack of a defined timeout when querying SSLLabs API.

<img width="1341" alt="leak" src="https://user-images.githubusercontent.com/16538065/78877234-d2278880-7a50-11ea-9d9a-510e754bdbe8.png">
