### PR TITLE
Code cleanup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,8 +23,9 @@ usage: ssllabs_exporter [<flags>]
 Flags:
   --help                     Show context-sensitive help (also try --help-long and --help-man).
   --listen-address=":19115"  The address to listen on for HTTP requests.
-  --timeout=300              Assessment timeout in seconds (including retries).
+  --timeout="10m"            Time duration before canceling an ongoing probe such as 30m or 1h5m. This value MUST be at least 1m. Valid duration units are ns, us (or µs), ms, s, m, h.
   --log-level=debug          Printed logs level.
+  --cache-retention="1h"     Time duration to keep entries in cache such as 30m or 1h5m. Valid duration units are ns, us (or µs), ms, s, m, h.
   --version                  Show application version.
 ```
 
@@ -51,7 +52,7 @@ The Grafana dashboard below is available [here](examples/grafana_dashboard.json)
 | ssllabs_probe_duration_seconds | how long the assessment took in seconds |
 | ssllabs_probe_success | whether we were able to fetch an assessment result from SSLLabs API (value of 1) or not (value of 0) regardless of the result content |
 | ssllabs_grade | the grade of the target host |
-| ssllabs_grade_age_seconds | when the result was generated in Unix time |
+| ssllabs_grade_time_seconds | when the result was generated in Unix time |
 
 #### `ssllabs_grade` possible values:
   - `1` : Assessment was successful and the grade is exposed in the `grade` label of the metric.

--- a/examples/grafana_dashboard.json
+++ b/examples/grafana_dashboard.json
@@ -272,7 +272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ssllabs_grade_age_seconds{instance=~\"$target\"} * 1000",
+          "expr": "ssllabs_grade_time_seconds{instance=~\"$target\"} * 1000",
           "interval": "",
           "legendFormat": "{{ instance }}",
           "refId": "A"

--- a/pkg/ssllabs/info.go
+++ b/pkg/ssllabs/info.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 // APIInfo /info endpoint result
@@ -30,7 +31,9 @@ type APIInfo struct {
 
 // Info calls /info endpoint and returns and Info
 func Info() (info APIInfo, err error) {
-	response, err := http.Get(API + "/info")
+	// TODO: make http timeout configurable
+	httpClient := http.Client{Timeout: 1 * time.Minute}
+	response, err := httpClient.Get(API + "/info")
 	if err != nil {
 		return
 	}

--- a/pkg/ssllabs/ssllabs.go
+++ b/pkg/ssllabs/ssllabs.go
@@ -25,7 +25,7 @@ const (
 	StatusInProgress = "IN_PROGRESS"
 	// StatusReady SSLLabs assessment finished successfully
 	StatusReady = "READY"
-	// StatusHTTPError error processing the HTTP request to SSLLabs API
+	// StatusHTTPError error processing the HTTP response from SSLLabs API
 	StatusHTTPError = "HTTP_ERROR"
 	// StatusServerError SSLLabs API server error or rate limiting
 	StatusServerError = "SERVER_ERROR"

--- a/ssllabs_exporter.go
+++ b/ssllabs_exporter.go
@@ -41,9 +41,9 @@ const (
 
 var (
 	listenAddress  = kingpin.Flag("listen-address", "The address to listen on for HTTP requests.").Default(":19115").String()
-	probeTimeout   = kingpin.Flag("timeout", "Time duration before canceling an ongoing probe such as 30m or 1h5m. This value must be at least 1m. Valid duration units are ns, us (or µs), ms, s, m, h.").Default("5m").String()
+	probeTimeout   = kingpin.Flag("timeout", "Time duration before canceling an ongoing probe such as 30m or 1h5m. This value must be at least 1m. Valid duration units are ns, us (or µs), ms, s, m, h.").Default("10m").String()
 	logLevel       = kingpin.Flag("log-level", "Printed logs level.").Default("debug").Enum("error", "warn", "info", "debug")
-	cacheRetention = kingpin.Flag("cache-retention", "Time duration to keep entries in cache such as 30m or 1h5m. Valid duration units are ns, us (or µs), ms, s, m, h.").Default("5m").String()
+	cacheRetention = kingpin.Flag("cache-retention", "Time duration to keep entries in cache such as 30m or 1h5m. Valid duration units are ns, us (or µs), ms, s, m, h.").Default("1h").String()
 
 	// build parameters
 	branch    string

--- a/ssllabs_exporter.go
+++ b/ssllabs_exporter.go
@@ -202,8 +202,6 @@ func createLogger(l string) (logger log.Logger, err error) {
 	logger = level.NewFilter(logger, lvl)
 	logger = log.With(logger, "timestamp", log.DefaultTimestampUTC)
 
-	logger.Log()
-
 	return logger, nil
 }
 

--- a/ssllabs_exporter_test.go
+++ b/ssllabs_exporter_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Anas Ait Said Oubrahim
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestGetTimeout(t *testing.T) {
+	var cases = []struct {
+		name              string
+		flagTimeout       time.Duration
+		prometheusTimeout string
+		expectedResult    time.Duration
+	}{
+		{
+			name:              "higher_prometheus_timeout",
+			flagTimeout:       1 * time.Second,
+			prometheusTimeout: "10",
+			expectedResult:    1 * time.Second,
+		},
+		{
+			name:              "lower_prometheus_timeout",
+			flagTimeout:       10 * time.Second,
+			prometheusTimeout: "1",
+			expectedResult:    1 * time.Second,
+		},
+		{
+			name:              "empty_prometheus_timeout",
+			flagTimeout:       1 * time.Second,
+			prometheusTimeout: "",
+			expectedResult:    1 * time.Second,
+		},
+		{
+			name:              "wrong_prometheus_timeout",
+			flagTimeout:       1 * time.Second,
+			prometheusTimeout: "not-parsable",
+			expectedResult:    1 * time.Second,
+		},
+	}
+
+	for _, c := range cases {
+		request, _ := http.NewRequest("", "", nil)
+		request.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", c.prometheusTimeout)
+		timeout := getTimeout(request, c.flagTimeout)
+		if timeout != c.expectedResult {
+			t.Errorf("Test case : %v failed.\nExpected : %v\nGot : %v\n", c.name, c.expectedResult, timeout)
+		}
+	}
+}

--- a/ssllabs_exporter_test.go
+++ b/ssllabs_exporter_test.go
@@ -62,3 +62,17 @@ func TestGetTimeout(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateLogger(t *testing.T) {
+	_, err := createLogger("unexpected")
+	if err == nil {
+		t.Errorf("logger created with unexpected level")
+	}
+
+	for _, lvl := range []string{"error", "warn", "info", "debug"} {
+		_, err := createLogger(lvl)
+		if err != nil {
+			t.Errorf("failed to create logger with level : %v", lvl)
+		}
+	}
+}


### PR DESCRIPTION
- cleanup some the main package code
- increase code coverage for the main package
- change metric name `ssllabs_grade_age_seconds` to `ssllabs_grade_time_seconds`
- change timeout flag from an `int` to a `time.Duration` for more human readable values
- change default value for cache retention flag from 5 minutes to 1 hour.
- change probe timeout behavior to use the min between Prometheus scrape timeout (if available) and the timeout value set via flag.
- update readme