### PR TITLE
Use Go 1.20 docker image for the build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-alpine3.15 AS builder
+FROM golang:1.20.3-alpine3.17 AS builder
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
I missed upgrade the docker image used for the binary build in the previous [PR](https://github.com/anas-aso/ssllabs_exporter/pull/36)