### PR TITLE
Fix uninitialized api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN export VERSION=$(cat version) && \
     export BRANCH=$(cat branch) && \
     export REVISION=$(cat revision) && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
-    -ldflags="-w -s -X github.com/anas-aso/ssllabs_exporter/build.Branch=${BRANCH} -X github.com/anas-aso/ssllabs_exporter/build.Revision=${REVISION} -X github.com/anas-aso/ssllabs_exporter/build.Version=${VERSION}" \
+    -ldflags="-w -s -X github.com/anas-aso/ssllabs_exporter/internal/build.Branch=${BRANCH} -X github.com/anas-aso/ssllabs_exporter/internal/build.Revision=${REVISION} -X github.com/anas-aso/ssllabs_exporter/internal/build.Version=${VERSION}" \
     -o /workdir/ssllabs_exporter
 
 # Create a "nobody" user for the next image

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -4,8 +4,8 @@ import "runtime"
 
 // build parameters
 var (
-	Branch    string
+	Branch    = "dev"
 	GoVersion = runtime.Version()
-	Revision  string
-	Version   string
+	Revision  = "n/a"
+	Version   = "n/a"
 )

--- a/internal/ssllabs/analyze.go
+++ b/internal/ssllabs/analyze.go
@@ -30,6 +30,9 @@ var api *ssllabsApi.API
 
 func init() {
 	api, _ = ssllabsApi.NewAPI("ssllabs-exporter", build.Version)
+	if api == nil {
+		panic("failed to initialize API client. this should never happen!")
+	}
 }
 
 // Analyze executes the SSL test HTTP requests


### PR DESCRIPTION
- fix build variables module path.
- fail on startup if API client is not initialized.
- set default values for build parameters to avoid failing tests.

the application versions are broken since [this PR](https://github.com/anas-aso/ssllabs_exporter/pull/30)